### PR TITLE
feat: store presentation and public keys in localStorage

### DIFF
--- a/machines/BridgingMachine.ts
+++ b/machines/BridgingMachine.ts
@@ -21,32 +21,32 @@ interface BridgingContext {
 
 type BridgingEvents =
   | {
-    type: "CREATE_CREDENTIAL";
-    message: string;
-    address: string;
-    signature: string;
-    walletAddress: string;
-    provider: any;
-  }
+      type: "CREATE_CREDENTIAL";
+      message: string;
+      address: string;
+      signature: string;
+      walletAddress: string;
+      provider: any;
+    }
   | {
-    type: "OBTAIN_CREDENTIAL";
-    provider: any;
-  }
+      type: "OBTAIN_CREDENTIAL";
+      provider: any;
+    }
   | {
-    type: "START_LOCK";
-    amount: number;
-    attestationHash: string;
-  }
+      type: "START_LOCK";
+      amount: number;
+      attestationHash: string;
+    }
   | {
-    type: "GET_LOCKED_TOKENS";
-  }
+      type: "GET_LOCKED_TOKENS";
+    }
   | { type: "RETRY" }
   | { type: "RESET" }
   | {
-    type: "UPDATE_MACHINE";
-    zkappWorkerClient: ZkappWorkerClient | null;
-    contract: Contract | null;
-  };
+      type: "UPDATE_MACHINE";
+      zkappWorkerClient: ZkappWorkerClient | null;
+      contract: Contract | null;
+    };
 
 export const BridgingMachine = setup({
   types: {
@@ -102,8 +102,8 @@ export const BridgingMachine = setup({
         if (!input.zkappWorkerClient) {
           throw new Error("Worker not ready - bridge");
         }
-        const request = await input.zkappWorkerClient.obtainPresentationRequest();
-        console.log("Obtained presentation request:", request.slice(0, 100), "...");
+        const request =
+          await input.zkappWorkerClient.obtainPresentationRequest();
         const result = await input.provider.request({
           method: "mina_requestPresentation",
           params: [
@@ -113,8 +113,7 @@ export const BridgingMachine = setup({
           ],
         });
         console.log("Presentation result:", result);
-
-        return result
+        return { credential: result, request };
       }
     ),
     lockTokens: fromPromise(
@@ -320,6 +319,7 @@ export const BridgingMachine = setup({
         onDone: {
           target: "obtained",
           actions: assign({
+            credential: ({ event }) => event.output.credential,
             errorMessage: null,
             step: "lock",
           }),


### PR DESCRIPTION
### Ticket
https://app.zenhub.com/workspaces/nori-68862b5949b20d0017254fb0/issues/gh/nori-zk/nori-bridge-zkapp/10

### Description
Saving result of obtainCredential to state within the state machine, then on change trigger a useEffect inside BridgingProvider to update localStorage with new values.

### Testing 
Manual testing.