### PR TITLE
#24: ENSURE USER CANNOT SELECT MAINNET IN WALLET

### DIFF
--- a/components/bridge-control-card/BridgeControlCard.tsx
+++ b/components/bridge-control-card/BridgeControlCard.tsx
@@ -30,6 +30,7 @@ const BridgeControlCard = ({
           chaos={0.5}
           thickness={2}
           style={{ borderRadius: 16 }}
+          className={""}
         >
           <BridgeControlCardContent
             width={width}


### PR DESCRIPTION
### Ticket
https://github.com/Nori-zk/nori-bridge-zkapp/issues/24

### Description
Adds a validateNetwork function used on signMessage and lockToken.
REQUIRED_NETWORK field provider wide netwrok values.
Check receipt value.
Set empty className value in ElectricBorder.