### PR TITLE
feat: use wagmina for wallet connection management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import Nori from "@/public/assets/Nori.svg";
 import BottomShadows from "@/public/assets/BottomShadows.svg";
 import ScrollingBridge from "@/components/panels/ScrollingBridge/ScrollingBridge.tsx";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider/MetaMaskWalletProvider.tsx";
-import { useAccount } from "wagmina";
 import Notification from "@/components/ui/Notification/Notification.tsx";
 import ChooseSides from "@/components/choose-side/ChooseSides.tsx";
 import { useBridgeControlCardProps } from "@/helpers/useBridgeControlCardProps.tsx";
@@ -13,6 +12,7 @@ import { useProgress } from "@/providers/ProgressProvider/ProgressProvider.tsx";
 import { Store } from "@/helpers/localStorage2.ts";
 import { useEffect, useState } from "react";
 import LaserFlow from "@/blocks/Animations/LaserFlow/LaserFlow.jsx";
+import { useAuroWallet } from "@/providers/AuroWalletProvider/AuroWalletProvider.tsx";
 
 export default function Home() {
   const [showMobileWarning, setShowMobileWarning] = useState<boolean>(false);
@@ -20,7 +20,8 @@ export default function Home() {
   const { showChooseSide } = useProgress();
 
   const { isConnected: ethConnected } = useMetaMaskWallet();
-  const { isConnected: minaConnected } = useAccount();
+  const { isConnected: minaConnected } = useAuroWallet();
+
   const { title, component } = useBridgeControlCardProps();
   const { state: bridgeState } = useNoriBridge();
 

--- a/components/DepositMintTestUI.tsx
+++ b/components/DepositMintTestUI.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useNoriBridge } from "@/providers/NoriBridgeProvider/NoriBridgeProvider.tsx";
 import WalletButton from "./ui/WalletButton/WalletButton.tsx";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider/MetaMaskWalletProvider.tsx";
-import { useAccount } from "wagmina";
 import { formatDisplayAddress } from "@/helpers/walletHelper.tsx";
+import { useAuroWallet } from "@/providers/AuroWalletProvider/AuroWalletProvider.tsx";
 
 export const DepositMintTestUI: React.FC = () => {
   const [depositNumber, setDepositNumberInput] = useState<string>("12345");
@@ -11,7 +11,7 @@ export const DepositMintTestUI: React.FC = () => {
 
   const { isConnected: ethConnected, displayAddress: ethDisplayAddress } =
     useMetaMaskWallet();
-  const { isConnected: minaConnected, address: minaAddress } = useAccount();
+  const { isConnected: minaConnected, walletAddress: minaAddress } = useAuroWallet();
   const {
     state,
     setDepositNumber,

--- a/components/bridge-control-card/BridgeControlCardContent/BridgeControlCardContent.tsx
+++ b/components/bridge-control-card/BridgeControlCardContent/BridgeControlCardContent.tsx
@@ -4,10 +4,10 @@ import BridgeControlCardSVG from "@/components/bridge-control-card/BridgeControl
 import Swap from "@/public/assets/Swap.svg";
 import DepositProgress from "@/components/bridge-control-card/DepositProgress/DepositProgress.tsx";
 import TextType from "@/blocks/TextAnimations/TextType/TextType.tsx";
-import { useAccount } from "wagmina";
 import { useNoriBridge } from "@/providers/NoriBridgeProvider/NoriBridgeProvider.tsx";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider/MetaMaskWalletProvider.tsx";
 import { formatDisplayAddress } from "@/helpers/walletHelper.tsx";
+import { useAuroWallet } from "@/providers/AuroWalletProvider/AuroWalletProvider.tsx";
 type BridgeControlCardPContentProps = {
   title: string;
   content?: ReactNode;
@@ -25,7 +25,7 @@ const BridgeControlCardContent = ({
 
   const { isConnected: ethConnected, displayAddress: ethDisplayAddress } =
     useMetaMaskWallet();
-  const { isConnected: minaConnected, address: minaAddress } = useAccount();
+  const { isConnected: minaConnected, walletAddress: minaAddress } = useAuroWallet();
   const { currentState } = useNoriBridge();
 
   useEffect(() => {

--- a/config/index.tsx
+++ b/config/index.tsx
@@ -1,8 +1,9 @@
 import { http } from "vimina";
 import { devnet, mainnet } from "vimina/chains";
 import { createConfig } from "wagmina";
+import { getConnectors } from "@wagmina/core";
 
-const chain = process.env.NEXT_PUBLIC_CHAIN === "mainnet" ? mainnet : devnet;
+export const chain = process.env.NEXT_PUBLIC_CHAIN === "mainnet" ? mainnet : devnet;
 
 export const config = createConfig({
   chains: [chain],
@@ -11,3 +12,11 @@ export const config = createConfig({
     [devnet.id]: http(),
   },
 });
+
+export function getWalletConnector() {
+  const connectors = getConnectors(config)
+  const palladConnector = connectors.find((c) => c.id === "co.pallad");
+  return (process.env.NEXT_PUBLIC_WALLET === "pallad" && palladConnector)
+      ? palladConnector
+      : connectors.find((c) => c.id === "com.aurowallet");
+}

--- a/helpers/useWalletButtonProps.tsx
+++ b/helpers/useWalletButtonProps.tsx
@@ -2,7 +2,6 @@ import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider/MetaMaskWa
 import { WalletButtonTypes } from "@/types/types.ts";
 import Mina from "@/public/assets/Mina.svg";
 import Ethereum from "@/public/assets/Ethereum.svg";
-import { useAccount } from "wagmina";
 import { formatDisplayAddress } from "./walletHelper.tsx";
 import { useAuroWallet } from "@/providers/AuroWalletProvider/AuroWalletProvider.tsx";
 
@@ -24,12 +23,12 @@ export function useWalletButtonProps(
   content: string = "Connect Wallet"
 ): WalletButtonUIProps {
   const eth = useMetaMaskWallet();
-  const { address, isConnected } = useAccount();
   const {
+    isConnected,
     isConnectingWalletOpen,
     connect,
     disconnect,
-    walletAddress: minaAddress,
+    walletAddress: address,
   } = useAuroWallet();
   const isEthereum = type === "Ethereum";
 

--- a/providers/NoriBridgeProvider/NoriBridgeProvider.tsx
+++ b/providers/NoriBridgeProvider/NoriBridgeProvider.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/machines/DepositMintMachine.ts";
 import { useSetup } from "../SetupProvider/SetupProvider.tsx";
 import { useMetaMaskWallet } from "../MetaMaskWalletProvider/MetaMaskWalletProvider.tsx";
-import { useAccount } from "wagmina";
 import ZkappMintWorkerClient from "@/workers/mintWorkerClient.ts";
 import { getBridgeMachine } from "@/machines/BridgeMachine.ts";
 import envConfig from "@/helpers/env.ts";
@@ -25,6 +24,7 @@ import getWorkerClient from "@/singletons/workerSingleton.ts";
 import { Store } from "@/helpers/localStorage2.ts";
 import { useToast } from "@/helpers/useToast.tsx";
 import { formatDisplayAddress } from "@/helpers/walletHelper.tsx";
+import { useAuroWallet } from "@/providers/AuroWalletProvider/AuroWalletProvider.tsx";
 
 // Extract the machine type
 type DepositMachine = ReturnType<typeof getDepositMachine>;
@@ -98,7 +98,7 @@ export const NoriBridgeProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const { ethStateTopic$, bridgeStateTopic$, bridgeTimingsTopic$ } = useSetup();
   const { walletAddress: ethAddress, disconnect } = useMetaMaskWallet();
-  const { address: minaAddress } = useAccount();
+  const { walletAddress: minaAddress } = useAuroWallet();
   const rawToast = useToast({
     type: "error",
     title: "Error",


### PR DESCRIPTION
I advise updating the vimina and wagmina packages as well, from here: https://github.com/wagmina/

The flow works perfectly with AuroWallet.

There are two issues regarding Pallad:
- a manual page refresh is required after switching the network, since Pallad does not broadcast the chainChanged event.
- Pallad does not support signing and sending a transaction at the same time, so for the flow to work with Pallad, the transaction should first be signed with `signTransaction` and then broadcast with `sendSignedTransaction`. Since this PR is mostly refactoring, I did not change the logic of this part.